### PR TITLE
Enhancement/access resources testably

### DIFF
--- a/api/src/main/java/vision/voltsofdoom/api/guice/Guicer.java
+++ b/api/src/main/java/vision/voltsofdoom/api/guice/Guicer.java
@@ -76,7 +76,7 @@ public class Guicer {
     String str;
 
     public static void main(String[] args) {
-      Guicer guicer = new Guicer(new ZapByteGuiceBindingModule());
+      Guicer guicer = new Guicer(new VODApiGuiceBindingModule());
       GuiceTest test = guicer.injector.getInstance(GuiceTest.class);
       test.test();
     }

--- a/api/src/main/java/vision/voltsofdoom/api/guice/VODApiGuiceBindingModule.java
+++ b/api/src/main/java/vision/voltsofdoom/api/guice/VODApiGuiceBindingModule.java
@@ -3,10 +3,11 @@ package vision.voltsofdoom.api.guice;
 import com.google.inject.AbstractModule;
 import vision.voltsofdoom.api.guice.Guicer.GuiceTest;
 
-public class ZapByteGuiceBindingModule extends AbstractModule {
+public class VODApiGuiceBindingModule extends AbstractModule {
 
   @Override
   protected void configure() {
     bind(GuiceTest.class).toInstance(new GuiceTest("thisisastring"));
   }
+
 }

--- a/voltsofdoom/src/main/java/vision/voltsofdoom/coresystem/play/adventure/Adventure.java
+++ b/voltsofdoom/src/main/java/vision/voltsofdoom/coresystem/play/adventure/Adventure.java
@@ -10,6 +10,7 @@ import vision.voltsofdoom.coresystem.play.adventure.Sheet.ISheetType;
 import vision.voltsofdoom.coresystem.universal.util.Reference;
 import vision.voltsofdoom.zapbyte.loading.registry.RegistryEntry;
 import vision.voltsofdoom.zapbyte.resource.IResourceLocation;
+import vision.voltsofdoom.zapbyte.resource.ZBSystemResourceHandler;
 
 /**
  * Contains all of the data for an Adventure!
@@ -52,8 +53,8 @@ public class Adventure extends RegistryEntry<Adventure> {
 
       for (LevelConfiguration config : configs) {
 
-        File file = new File(Reference.ADVENTURE + this.configuration.getIdentifier().getEntry()
-            + "_" + this.configuration.getVersion() + ".zip");
+        File file = ZBSystemResourceHandler.instance.getFile(() -> (Reference.ADVENTURE + this.configuration.getIdentifier().getEntry()
+            + "_" + this.configuration.getVersion() + ".zip"));
         levelArr.add(Level.fromZip(this, new ZipFile(file), config));
       }
     } catch (Exception e) {

--- a/voltsofdoom/src/main/java/vision/voltsofdoom/coresystem/play/adventure/AdventureLoader.java
+++ b/voltsofdoom/src/main/java/vision/voltsofdoom/coresystem/play/adventure/AdventureLoader.java
@@ -24,6 +24,7 @@ import vision.voltsofdoom.zapbyte.event.RegistryEvent;
 import vision.voltsofdoom.zapbyte.event.Stowaway;
 import vision.voltsofdoom.zapbyte.log.Loggers;
 import vision.voltsofdoom.zapbyte.main.ZapByteReference;
+import vision.voltsofdoom.zapbyte.resource.ZBSystemResourceHandler;
 
 /**
  * Generates a list of {@link Adventure}s to register.
@@ -63,7 +64,7 @@ public class AdventureLoader {
   private static void generateAdventures(GenerateAdventuresEvent event)
       throws FileNotFoundException {
     List<ZipFile> adventureZips = new ArrayList<ZipFile>();
-    File adventureFolder = new File(Reference.ADVENTURE);
+    File adventureFolder = ZBSystemResourceHandler.instance.getFile(() -> Reference.ADVENTURE);
     if (!adventureFolder.exists() || !adventureFolder.isDirectory()) {
       adventureFolder.mkdir();
       throw new FileNotFoundException("Adventure folder in the located Volts of Doom directory"

--- a/voltsofdoom/src/main/java/vision/voltsofdoom/coresystem/universal/resource/image/VODImage.java
+++ b/voltsofdoom/src/main/java/vision/voltsofdoom/coresystem/universal/resource/image/VODImage.java
@@ -6,6 +6,7 @@ import java.net.URI;
 import java.net.URL;
 import javax.imageio.ImageIO;
 import vision.voltsofdoom.zapbyte.log.Loggers;
+import vision.voltsofdoom.zapbyte.resource.ZBSystemResourceHandler;
 
 /**
  * Holds an image for the game, in an expected format, with additional utility methods thrown in for
@@ -20,7 +21,7 @@ public class VODImage {
 
   public VODImage(String path) {
     try {
-      File f = new File(path);
+      File f = ZBSystemResourceHandler.instance.getFile(() -> path);
 
       URI formattedUri = new URI(f.getAbsolutePath().replace("\\", "/"));
       url = new URL("file://" + formattedUri.getPath());

--- a/zapbyte/src/main/java/vision/voltsofdoom/zapbyte/config/ConfigHandler.java
+++ b/zapbyte/src/main/java/vision/voltsofdoom/zapbyte/config/ConfigHandler.java
@@ -13,6 +13,7 @@ import vision.voltsofdoom.api.zapyte.config.IConfigurationFile;
 import vision.voltsofdoom.zapbyte.log.Loggers;
 import vision.voltsofdoom.zapbyte.main.ZapByteReference;
 import vision.voltsofdoom.zapbyte.misc.util.StacktraceUtils;
+import vision.voltsofdoom.zapbyte.resource.ZBSystemResourceHandler;
 
 public class ConfigHandler implements IConfigHandler {
 
@@ -37,13 +38,13 @@ public class ConfigHandler implements IConfigHandler {
   @Override
   public void loadConfigurationFile() {
 
-    File configFile = new File(ZapByteReference.getConfig() + CONFIG_FILE);
+    File configFile = ZBSystemResourceHandler.instance.getFile_canIgnoreMissing(() -> ZapByteReference.getConfig() + CONFIG_FILE, true);
 
     // If the configuration file does not exist...
     if (!configFile.exists()) {
       Loggers.ZAPBYTE.info("Configuration file does not exist at: " + configFile);
 
-      new File(ZapByteReference.getConfig()).mkdirs();
+      ZBSystemResourceHandler.instance.getFile_canIgnoreMissing(() -> ZapByteReference.getConfig(), true).mkdirs();
 
       // Make new file and write default values.
       try {

--- a/zapbyte/src/main/java/vision/voltsofdoom/zapbyte/log/Handlers.java
+++ b/zapbyte/src/main/java/vision/voltsofdoom/zapbyte/log/Handlers.java
@@ -1,11 +1,11 @@
 package vision.voltsofdoom.zapbyte.log;
 
-import java.io.File;
 import java.util.Calendar;
 import java.util.logging.ConsoleHandler;
 import java.util.logging.FileHandler;
 import java.util.logging.Handler;
 import vision.voltsofdoom.zapbyte.main.ZapByteReference;
+import vision.voltsofdoom.zapbyte.resource.ZBSystemResourceHandler;
 
 /**
  * Logging {@link Handler}s.
@@ -37,7 +37,7 @@ public class Handlers {
   static {
     try {
 
-      new File(baseFilePath).mkdirs();
+      ZBSystemResourceHandler.instance.getFile_canIgnoreMissing(() -> baseFilePath, true).mkdirs();
 
       FILE_HANDLER_ONE = new FileHandler(TIER_ONE_PATH, 51200, 1, false);
       CONSOLE_HANDLER_ONE = new ConsoleHandler();

--- a/zapbyte/src/main/java/vision/voltsofdoom/zapbyte/main/ZapByte.java
+++ b/zapbyte/src/main/java/vision/voltsofdoom/zapbyte/main/ZapByte.java
@@ -48,9 +48,8 @@ public abstract class ZapByte {
    */
   public ZapByte(String applicationNamespace) {
     ZapByteReference.APPLICATION_NAMESPACE = applicationNamespace;
-
     setGuicer(new Guicer(new ZapByteGuiceBindingModule()));
-    
+
     this.zapBits = new HashSet<ZapBit>();
     this.configHandler = new ConfigHandler();
 
@@ -64,7 +63,7 @@ public abstract class ZapByte {
    * loading.
    */
   public abstract void collectZapbits();
-  
+
   public abstract void continueExecution();
 
   public void run() {
@@ -94,11 +93,12 @@ public abstract class ZapByte {
     for (Integer integer : ints) {
       bits.get(integer).run();
     }
-    
-    Loggers.ZAPBYTE.warning("ZapBit execution complete. Continuing external (none-ZapBit) execution.");
-    
+
+    Loggers.ZAPBYTE
+        .warning("ZapBit execution complete. Continuing external (none-ZapBit) execution.");
+
     continueExecution();
-    
+
     Loggers.ZAPBYTE.severe("ZapByte cycle complete. Exiting.");
     System.exit(1);
   }
@@ -120,7 +120,7 @@ public abstract class ZapByte {
   public Set<ZapBit> getZapBits() {
     return zapBits;
   }
-  
+
   public ZBSystemResourceHandler getZbSystemResourceHandler() {
     return zbSystemResourceHandler;
   }
@@ -142,7 +142,7 @@ public abstract class ZapByte {
   protected void setZapBits(Set<ZapBit> zapBits) {
     this.zapBits = zapBits;
   }
-  
+
   public void setZbSystemResourceHandler(ZBSystemResourceHandler zbSystemResourceHandler) {
     this.zbSystemResourceHandler = zbSystemResourceHandler;
   }

--- a/zapbyte/src/main/java/vision/voltsofdoom/zapbyte/main/ZapByte.java
+++ b/zapbyte/src/main/java/vision/voltsofdoom/zapbyte/main/ZapByte.java
@@ -8,11 +8,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import vision.voltsofdoom.api.guice.Guicer;
-import vision.voltsofdoom.api.guice.ZapByteGuiceBindingModule;
 import vision.voltsofdoom.api.guice.Guicer.GuiceTest;
 import vision.voltsofdoom.api.zapyte.config.IConfigHandler;
 import vision.voltsofdoom.zapbyte.config.ConfigHandler;
 import vision.voltsofdoom.zapbyte.log.Loggers;
+import vision.voltsofdoom.zapbyte.resource.ZBSystemResourceHandler;
 
 /**
  * The main class of the {@link ZapByte} module. Any application wishing to use {@link ZapByte}
@@ -28,6 +28,7 @@ public abstract class ZapByte {
   private IConfigHandler configHandler;
   private Guicer guicer;
   public static final String ZAPBYTE = "zapbyte";
+  private ZBSystemResourceHandler zbSystemResourceHandler;
 
   /**
    * Constructs a new root class for a {@link ZapByte} driven application loading cycle. <br>
@@ -49,12 +50,13 @@ public abstract class ZapByte {
     ZapByteReference.APPLICATION_NAMESPACE = applicationNamespace;
 
     setGuicer(new Guicer(new ZapByteGuiceBindingModule()));
-
+    
     this.zapBits = new HashSet<ZapBit>();
     this.configHandler = new ConfigHandler();
 
     @SuppressWarnings("unused")
     GuiceTest guiceTest = guicer.getInjector().getInstance(GuiceTest.class);
+    setZbSystemResourceHandler(guicer.getInjector().getInstance(ZBSystemResourceHandler.class));
   }
 
   /**
@@ -118,6 +120,10 @@ public abstract class ZapByte {
   public Set<ZapBit> getZapBits() {
     return zapBits;
   }
+  
+  public ZBSystemResourceHandler getZbSystemResourceHandler() {
+    return zbSystemResourceHandler;
+  }
 
   // Set
 
@@ -135,5 +141,9 @@ public abstract class ZapByte {
 
   protected void setZapBits(Set<ZapBit> zapBits) {
     this.zapBits = zapBits;
+  }
+  
+  public void setZbSystemResourceHandler(ZBSystemResourceHandler zbSystemResourceHandler) {
+    this.zbSystemResourceHandler = zbSystemResourceHandler;
   }
 }

--- a/zapbyte/src/main/java/vision/voltsofdoom/zapbyte/main/ZapByteGuiceBindingModule.java
+++ b/zapbyte/src/main/java/vision/voltsofdoom/zapbyte/main/ZapByteGuiceBindingModule.java
@@ -1,0 +1,11 @@
+package vision.voltsofdoom.zapbyte.main;
+
+import com.google.inject.AbstractModule;
+
+public class ZapByteGuiceBindingModule extends AbstractModule {
+
+  @Override
+  protected void configure() {
+    
+  }
+}

--- a/zapbyte/src/main/java/vision/voltsofdoom/zapbyte/resource/IResource.java
+++ b/zapbyte/src/main/java/vision/voltsofdoom/zapbyte/resource/IResource.java
@@ -1,0 +1,12 @@
+package vision.voltsofdoom.zapbyte.resource;
+
+/**
+ * Could be anything from a PNG to a JAR or a JSON.
+ * 
+ * @author GenElectrovise
+ *
+ */
+@FunctionalInterface
+public interface IResource {
+  public String getPath();
+}

--- a/zapbyte/src/main/java/vision/voltsofdoom/zapbyte/resource/ISystemResourceHandler.java
+++ b/zapbyte/src/main/java/vision/voltsofdoom/zapbyte/resource/ISystemResourceHandler.java
@@ -1,0 +1,13 @@
+package vision.voltsofdoom.zapbyte.resource;
+
+import java.io.File;
+
+/**
+ * Handles {@link ISystemResource}s so you don't have to!
+ * 
+ * @author GenElectrovise
+ *
+ */
+public interface ISystemResourceHandler {
+  public File getFile(IResource resource);
+}

--- a/zapbyte/src/main/java/vision/voltsofdoom/zapbyte/resource/ISystemResourceHandler.java
+++ b/zapbyte/src/main/java/vision/voltsofdoom/zapbyte/resource/ISystemResourceHandler.java
@@ -9,5 +9,11 @@ import java.io.File;
  *
  */
 public interface ISystemResourceHandler {
+  /**
+   * Retrieves a {@link File} from the file system.
+   * 
+   * @param resource An {@link IResource} denoting where to find the desired {@link File}.
+   * @return The {@link File}.
+   */
   public File getFile(IResource resource);
 }

--- a/zapbyte/src/main/java/vision/voltsofdoom/zapbyte/resource/JarMapper.java
+++ b/zapbyte/src/main/java/vision/voltsofdoom/zapbyte/resource/JarMapper.java
@@ -21,6 +21,7 @@ public class JarMapper {
     ArrayList<File> out = new ArrayList<File>();
     
     File modsDir = ZBSystemResourceHandler.instance.getFile(() -> ZapByteReference.getModsDir());
+    
     for (File file : modsDir.listFiles()) {
       if (file.getName().endsWith(".jar")) {
         out.add(file);

--- a/zapbyte/src/main/java/vision/voltsofdoom/zapbyte/resource/JarMapper.java
+++ b/zapbyte/src/main/java/vision/voltsofdoom/zapbyte/resource/JarMapper.java
@@ -19,8 +19,8 @@ public class JarMapper {
    */
   public static ArrayList<File> find() {
     ArrayList<File> out = new ArrayList<File>();
-
-    File modsDir = new File(ZapByteReference.getModsDir());
+    
+    File modsDir = ZBSystemResourceHandler.instance.getFile(() -> ZapByteReference.getModsDir());
     for (File file : modsDir.listFiles()) {
       if (file.getName().endsWith(".jar")) {
         out.add(file);

--- a/zapbyte/src/main/java/vision/voltsofdoom/zapbyte/resource/ZBSystemResourceHandler.java
+++ b/zapbyte/src/main/java/vision/voltsofdoom/zapbyte/resource/ZBSystemResourceHandler.java
@@ -1,19 +1,54 @@
 package vision.voltsofdoom.zapbyte.resource;
 
 import java.io.File;
+import java.io.FileNotFoundException;
+import vision.voltsofdoom.zapbyte.log.Loggers;
 
 public class ZBSystemResourceHandler implements ISystemResourceHandler {
-  
-  public static ISystemResourceHandler instance = new ZBSystemResourceHandler();
+
+  public static ZBSystemResourceHandler instance = new ZBSystemResourceHandler();
 
   @Override
   public File getFile(IResource resource) {
-    /*
-     * if (!IResource.isValid(resource)) { Loggers.ZAPBYTE_LOADING_RESOURCE.severe("Invalid " +
-     * IResource.class.getSimpleName() + " passed to " + getClass().getSimpleName() +
-     * "#getFile()!"); }
-     */
-    return new File(resource.getPath());
+    return getFile_canIgnoreMissing(resource, false);
+  }
+
+  /**
+   * {@link #getFile(IResource)}, but can specify whether to ignore whether the {@link File} exists
+   * or not.
+   * 
+   * @param resource The location of the {@link File} to retrieve.
+   * @param ignoreMissing If the {@link File} doesn't exist, setting this to <code>true</code> will
+   *        prevent throwing an exception.
+   * @return The {@link File}.
+   * @throws FileNotFoundException If shouldn't <code>ignoreMissing</code>, and the {@link File}
+   *         doesn't exist.
+   */
+  public File getFile_canIgnoreMissing(IResource resource, boolean ignoreMissing) {
+    try {
+
+      File file = new File(resource.getPath());
+      boolean exists = file.exists();
+
+      // If should ignore missing
+      if (ignoreMissing) {
+        return file;
+      }
+
+      // If the file doesn't exist (and isn't ignored)
+      if (!exists) {
+        throw new FileNotFoundException(
+            "Could not return File denoted by IResource path " + resource.getPath());
+      }
+
+      // If the file exists, return it.
+      return file;
+
+    } catch (FileNotFoundException e) {
+      e.printStackTrace();
+      Loggers.ZAPBYTE_LOADING_RESOURCE.throwing(getClass().getSimpleName(), "getFile", e);
+      return null;
+    }
   }
 
 }

--- a/zapbyte/src/main/java/vision/voltsofdoom/zapbyte/resource/ZBSystemResourceHandler.java
+++ b/zapbyte/src/main/java/vision/voltsofdoom/zapbyte/resource/ZBSystemResourceHandler.java
@@ -1,0 +1,19 @@
+package vision.voltsofdoom.zapbyte.resource;
+
+import java.io.File;
+
+public class ZBSystemResourceHandler implements ISystemResourceHandler {
+  
+  public static ISystemResourceHandler instance = new ZBSystemResourceHandler();
+
+  @Override
+  public File getFile(IResource resource) {
+    /*
+     * if (!IResource.isValid(resource)) { Loggers.ZAPBYTE_LOADING_RESOURCE.severe("Invalid " +
+     * IResource.class.getSimpleName() + " passed to " + getClass().getSimpleName() +
+     * "#getFile()!"); }
+     */
+    return new File(resource.getPath());
+  }
+
+}


### PR DESCRIPTION
```File```s are now accessed solely (to my knowledge and searching power) through use of: ```ZBSystemResourceManager._instance_.getFile(IResource, boolean)```, where the _boolean_ value is _ignoreExists_.